### PR TITLE
Add support for Python 3.8 -> 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Version 1.1.0](https://github.com/dataiku/dss-plugin-azure-cognitive-services-nlp/releases/tag/v1.1.0) - 2023-05
+
+- ✨ Added support for Python 3.8, 3.9, 3.10, 3.11

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,10 +1,15 @@
 {
-	"acceptedPythonInterpreters": [
-		"PYTHON35",
-		"PYTHON36",
-		"PYTHON37"
-	],
-	"forceConda": false,
-	"installCorePackages": true,
-	"installJupyterSupport": false
+    "acceptedPythonInterpreters": [
+        "PYTHON35",
+        "PYTHON36",
+        "PYTHON37",
+        "PYTHON38",
+        "PYTHON39",
+        "PYTHON310",
+        "PYTHON311"
+    ],
+    "corePackagesSet": "AUTO",
+    "forceConda": false,
+    "installCorePackages": true,
+    "installJupyterSupport": false
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "azure-cognitive-services-nlp",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "meta": {
         "label": "Azure Cognitive Services - Text Analytics",
         "category": "Natural Language Processing",


### PR DESCRIPTION
Re-usable test setup if you want to play with it:
- For each Python 3.6 -> 3.1:
- Change code env of plugin
   - https://staging-design.qa.managedinstances.dkucloud-dev.com/plugins/development/azure-cognitive-services-nlp/definition/
   - No need to build container images
- Run the plugin recipe
   - Language detection: https://staging-design.qa.managedinstances.dkucloud-dev.com/projects/TESTAZURENLP/recipes/compute_languagedetected/
   - Sentiment analysis: https://staging-design.qa.managedinstances.dkucloud-dev.com/projects/TESTAZURENLP/recipes/compute_senti/
   - You may want to try the two others (testing with Python 3.11 is probably enough)
